### PR TITLE
feat: use api to determine required user privileges for sections

### DIFF
--- a/src/Maintenance.app.js
+++ b/src/Maintenance.app.js
@@ -60,6 +60,7 @@ export const Maintenance = () => (
                     <ProtectedRoute
                         exact
                         path={dataElement.sections.dataElement.path}
+                        schemaName={dataElement.sections.dataElement.schemaName}
                         permissions={
                             dataElement.sections.dataElement.permissions
                         }

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,55 +1,14 @@
-import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { push } from 'connected-react-router'
-import { ScrollBar, TabBar, Tab } from '@dhis2/ui-core'
-import React, { useCallback } from 'react'
-
+import { ScrollBar, TabBar } from '@dhis2/ui-core'
+import React from 'react'
 import cx from 'classnames'
 
 import { mainSectionOrder } from '../constants/sectionOrder'
-import styles from './Navigation.module.css'
+import { NavigationLink } from './Navigation/NavigationLink'
 
-const useOnClick = (disabled, push, to) =>
-    useCallback(
-        e => {
-            disabled ? e.preventDefault() : push(to)
-        },
-        [disabled, to, push]
-    )
-
-const isNavLinkActive = (path, currentPath) => {
-    if (path === currentPath) return true
-
-    const section = currentPath
-        .replace(/^\//, '') // remove possible leading slash
-        .split('/')[1] // field 1 contains the section, field 0 is the mode (edit / list)
-
-    return path.match(section)
-}
-
-const NavigationLink = connect(
-    state =>
-        console.log(state.router) || {
-            pathname: state.router.location.pathname,
-        },
-    dispatch => ({ push: path => dispatch(push(path)) })
-)(({ pathname, to, disabled, label, push }) => {
-    const onClick = useOnClick(disabled, push, to)
-
+const NavigationComponent = ({ disabled }) => {
     return (
-        <Tab selected={isNavLinkActive(to, pathname)} onClick={onClick}>
-            {label}
-        </Tab>
-    )
-})
-
-const Navigation = ({ disabled }) => {
-    return (
-        <nav
-            className={cx({
-                [styles.disabled]: disabled,
-            })}
-        >
+        <nav className={cx({ disabled })}>
             <ScrollBar>
                 <TabBar fixed>
                     <NavigationLink
@@ -72,8 +31,10 @@ const Navigation = ({ disabled }) => {
     )
 }
 
-const ConnectedNavigation = connect(({ navigation }) => ({
+const mapStateToProps = ({ navigation }) => ({
     disabled: navigation.disabled,
-}))(Navigation)
+})
 
-export { ConnectedNavigation as Navigation }
+const Navigation = connect(mapStateToProps)(NavigationComponent)
+
+export { Navigation }

--- a/src/components/Navigation/NavigationLink.js
+++ b/src/components/Navigation/NavigationLink.js
@@ -1,0 +1,54 @@
+import { nth, pipe, replace, split } from 'lodash/fp'
+import { connect } from 'react-redux'
+import { push } from 'connected-react-router'
+import { Tab } from '@dhis2/ui-core'
+import React, { useCallback } from 'react'
+
+const replacePossibleLeadingSlash = replace(/^\//, '')
+
+const getSectionFromPathSegments = pipe(
+    split('/'),
+    nth(1)
+)
+
+const extractSectionFromPath = pipe(
+    replacePossibleLeadingSlash,
+    getSectionFromPathSegments
+)
+
+const useOnClick = (disabled, push, to) =>
+    useCallback(
+        e => {
+            disabled ? e.preventDefault() : push(to)
+        },
+        [disabled, to, push]
+    )
+
+const isNavLinkActive = (path, currentPath) => {
+    if (path === currentPath) return true
+
+    const section = extractSectionFromPath(currentPath)
+
+    return path.match(section)
+}
+
+const NavigationLinkComponent = ({ pathname, to, disabled, label, push }) => {
+    const onClick = useOnClick(disabled, push, to)
+
+    return (
+        <Tab selected={isNavLinkActive(to, pathname)} onClick={onClick}>
+            {label}
+        </Tab>
+    )
+}
+
+const mapStateToProps = ({ router }) => ({ pathname: router.location.pathname })
+
+const mapDispatchToProps = dispatch => ({ push: path => dispatch(push(path)) })
+
+const NavigationLink = connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(NavigationLinkComponent)
+
+export { NavigationLink }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -11,8 +11,13 @@ import { sectionPropType } from './authorization/sectionPropType'
 const Sidebar = ({ sections, location }) => (
     <GridSidebar>
         <MenuList>
-            {sections.map(({ name, path, permissions }) => (
-                <ProtectedLink key={path} to={path} permissions={permissions}>
+            {sections.map(({ name, path, permissions, schemaName }) => (
+                <ProtectedLink
+                    key={path}
+                    to={path}
+                    permissions={permissions}
+                    schemaName={schemaName}
+                >
                     <MenuItem
                         key={name}
                         icon={<FolderClosed />}

--- a/src/components/authorization/ProtectedLink.js
+++ b/src/components/authorization/ProtectedLink.js
@@ -7,19 +7,26 @@ import { hasUserAuthorityForSection } from '../../utils/authority/hasUserAuthori
 import { queries } from '../../constants/queries'
 import styles from './ProtectedLink.module.css'
 
-export const ProtectedLink = ({ permissions, ...rest }) => {
-    const { loading, error, data = {} } = useDataQuery({
+export const ProtectedLink = ({ permissions, schemaName, ...rest }) => {
+    const query = {
         authorities: queries.authorities,
         systemSettings: queries.systemSettings,
-    })
+    }
+
+    if (schemaName) {
+        query.schema = { resource: `schemas/${schemaName}.json` }
+    }
+
+    const { loading, error, data = {} } = useDataQuery(query)
 
     const hasAuthorityToViewSection =
         !loading && !error
-            ? hasUserAuthorityForSection(
-                  data.authorities,
-                  data.systemSettings,
-                  permissions
-              )
+            ? hasUserAuthorityForSection({
+                  authorities: data.authorities,
+                  systemSettings: data.systemSettings,
+                  schema: data.schema,
+                  permissions,
+              })
             : false
 
     return hasAuthorityToViewSection ? (
@@ -30,4 +37,9 @@ export const ProtectedLink = ({ permissions, ...rest }) => {
 ProtectedLink.propTypes = {
     ...Link.propTypes,
     permissions: propTypes.arrayOf(propTypes.string),
+    schemaName: propTypes.string,
+}
+
+ProtectedLink.defaultProps = {
+    schemaName: '',
 }

--- a/src/components/authorization/ProtectedRoute.js
+++ b/src/components/authorization/ProtectedRoute.js
@@ -21,11 +21,12 @@ const determineComponent = ({
     if (error) return () => <Error error={error} />
 
     if (
-        hasUserAuthorityForSection(
-            data.authorities,
-            data.systemSettings,
-            permissions
-        )
+        hasUserAuthorityForSection({
+            authorities: data.authorities,
+            systemSettings: data.systemSettings,
+            schema: data.schema,
+            permissions,
+        })
     ) {
         return component
     }
@@ -34,10 +35,16 @@ const determineComponent = ({
 }
 
 export const ProtectedRoute = props => {
-    const { loading, error, data } = useDataQuery({
+    const query = {
         authorities: queries.authorities,
         systemSettings: queries.systemSettings,
-    })
+    }
+
+    if (props.schemaName) {
+        query.schema = `schema/${props.schemaName}.json`
+    }
+
+    const { loading, error, data } = useDataQuery(query)
 
     return (
         <Route
@@ -55,4 +62,9 @@ export const ProtectedRoute = props => {
 ProtectedRoute.propTypes = {
     ...Route.propTypes,
     permissions: propTypes.arrayOf(propTypes.string),
+    schemaName: propTypes.string,
+}
+
+ProtectedRoute.defaultProps = {
+    schemaName: '',
 }

--- a/src/constants/sections.js
+++ b/src/constants/sections.js
@@ -9,66 +9,42 @@ export const sections = {
                 path: '/list/categorySection/categoryOption',
                 description:
                     'Create, modify, view and delete data element category options. Category options are options with in category.',
-                permissions: [
-                    'F_CATEGORY_OPTION_PRIVATE_ADD',
-                    'F_CATEGORY_OPTION_PUBLIC_ADD',
-                    'F_CATEGORY_OPTION_DELETE',
-                ],
+                schemaName: 'categoryOption',
             },
             category: {
                 name: 'Category',
                 path: '/list/categorySection/category',
                 description:
                     'Create, modify, view and delete data element categories. Categories are used for disaggregation of data elements.',
-                permissions: [
-                    'F_CATEGORY_PRIVATE_ADD',
-                    'F_CATEGORY_PUBLIC_ADD',
-                    'F_CATEGORY_DELETE',
-                ],
+                schemaName: 'category',
             },
             categoryCombo: {
                 name: 'Category combination',
                 path: '/list/categorySection/categoryCombo',
                 description:
                     'msgid "Create, modify, view and delete data element category combinations.',
-                permissions: [
-                    'F_CATEGORY_COMBO_PRIVATE_ADD',
-                    'F_CATEGORY_COMBO_PUBLIC_ADD',
-                    'F_CATEGORY_COMBO_DELETE',
-                ],
+                schemaName: 'categoryCombo',
             },
             categoryOptionCombo: {
                 name: 'Category option combination',
                 path: '/list/categorySection/categoryOptionCombo',
                 description:
                     'View and edit data element category option combinations. Category option combinations are break-downs of category.',
-                permissions: [
-                    'F_CATEGORY_OPTION_COMBO_PRIVATE_ADD',
-                    'F_CATEGORY_OPTION_COMBO_PUBLIC_ADD',
-                    'F_CATEGORY_OPTION_COMBO_DELETE',
-                ],
+                schemaName: 'categoryOptionCombo',
             },
             categoryOptionGroup: {
                 name: 'Category option group',
                 path: '/list/categorySection/categoryOptionGroup',
                 description:
                     'Create, modify, view and delete category option groups, which can be used to classify category options.',
-                permissions: [
-                    'F_CATEGORY_OPTION_GROUP_PRIVATE_ADD',
-                    'F_CATEGORY_OPTION_GROUP_PUBLIC_ADD',
-                    'F_CATEGORY_OPTION_GROUP_DELETE',
-                ],
+                schemaName: 'categoryOptionGroup',
             },
             categoryOptionGroupSet: {
                 name: 'Category option group set',
                 path: '/list/categorySection/categoryOptionGroupSet',
                 description:
                     'Create, modify, view and delete category option group sets, which can be used for improved data analysis.',
-                permissions: [
-                    'F_CATEGORY_OPTION_GROU_SET_PRIVATE_ADD',
-                    'F_CATEGORY_OPTION_GROU_SET_PUBLIC_ADD',
-                    'F_CATEGORY_OPTION_GROU_SET_DELETE',
-                ],
+                schemaName: 'categoryOptionGroupSet',
             },
         },
     },
@@ -82,33 +58,21 @@ export const sections = {
                 path: '/list/dataElementSection/dataElement',
                 description:
                     'Create, modify, view and delete data elements. Data elements are phenomena for which will be captured and analyzed.',
-                permissions: [
-                    'F_DATAELEMENT_PRIVATE_ADD',
-                    'F_DATAELEMENT_PUBLIC_ADD',
-                    'F_DATAELEMENT_DELETE',
-                ],
+                schemaName: 'dataElement',
             },
             dataElementGroup: {
                 name: 'Data element group',
                 path: '/list/dataElementSection/dataElementGroup',
                 description:
                     'Create, modify, view and delete data element groups. Groups are used for improved analysis.',
-                permissions: [
-                    'F_DATAELEMENTGROUP_PRIVATE_ADD',
-                    'F_DATAELEMENTGROUP_PUBLIC_ADD',
-                    'F_DATAELEMENTGROUP_DELETE',
-                ],
+                schemaName: 'dataElementGroup',
             },
             dataElementGroupSet: {
                 name: 'Data element group set',
                 path: '/list/dataElementSection/dataElementGroupSet',
                 description:
                     'Create, modify, view and delete data element group sets. Group sets are used for improved analysis.',
-                permissions: [
-                    'F_DATAELEMENTGROUPSET_PRIVATE_ADD',
-                    'F_DATAELEMENTGROUPSET_PUBLIC_ADD',
-                    'F_DATAELEMENTGROUPSET_DELETE',
-                ],
+                schemaName: 'dataElementGroupSet',
             },
         },
     },
@@ -122,21 +86,13 @@ export const sections = {
                 path: '/list/dataSetSection/dataSet',
                 description:
                     'Create, update, view and delete data sets and custom forms. A data set is a collection of data elements for which data is entered.',
-                permissions: [
-                    'F_DATA_SET_PRIVATE_ADD',
-                    'F_DATA_SET_PUBLIC_ADD',
-                    'F_DATA_SET_DELETE',
-                ],
+                schemaName: 'dataSet',
             },
             dataSetNotification: {
                 name: 'Data set notifications',
                 path: '/list/dataSetSection/dataSetNotificationTemplate',
                 description: '', // @TODO
-                permissions: [
-                    'F_DATA_SET_NOTIFICATIONS_PRIVATE_ADD',
-                    'F_DATA_SET_NOTIFICATIONS_PUBLIC_ADD',
-                    'F_DATA_SET_NOTIFICATIONS_DELETE',
-                ],
+                schemaName: 'dataSetNotificationTemplate',
             },
         },
     },
@@ -150,64 +106,40 @@ export const sections = {
                 path: '/list/indicatorSection/indicator',
                 description:
                     'Create, modify, view and delete indicators. An indicator is a formula consisting of data elements and numbers.',
-                permissions: [
-                    'F_INDICATOR_PRIVATE_ADD',
-                    'F_INDICATOR_PUBLIC_ADD',
-                    'F_INDICATOR_DELETE',
-                ],
+                schemaName: 'indicator',
             },
             indicatorType: {
                 name: 'Indicator type',
                 path: '/list/indicatorSection/indicatorType',
                 description:
                     'Create, modify, view and delete indicator types. An indicator type is a factor for an indicator, like percentage.',
-                permissions: [
-                    'F_INDICATOR_TYPE_PRIVATE_ADD',
-                    'F_INDICATOR_TYPE_PUBLIC_ADD',
-                    'F_INDICATOR_TYPE_DELETE',
-                ],
+                schemaName: 'indicatorType',
             },
             indicatorGroup: {
                 name: 'Indicator group',
                 path: '/list/indicatorSection/indicatorGroup',
                 description:
                     'Create, modify, view and delete indicator groups. Groups are used for improved analysis.',
-                permissions: [
-                    'F_INDICATOR_GROUP_PRIVATE_ADD',
-                    'F_INDICATOR_GROUP_PUBLIC_ADD',
-                    'F_INDICATOR_GROUP_DELETE',
-                ],
+                schemaName: 'indicatorGroup',
             },
             indicatorGroupSet: {
                 name: 'Indicator group set',
                 path: '/list/indicatorSection/indicatorGroupSet',
                 description:
                     'Create, modify, view and delete indicator group sets. Group sets are used for improved analysis.',
-                permissions: [
-                    'F_INDICATOR_GROUP_SET_PRIVATE_ADD',
-                    'F_INDICATOR_GROUP_SET_PUBLIC_ADD',
-                    'F_INDICATOR_GROUP_SET_DELETE',
-                ],
+                schemaName: 'indicatorGroupSet',
             },
             programIndicator: {
                 name: 'Program indicator',
                 path: '/list/indicatorSection/programIndicator',
                 description: '', // @TODO
-                permissions: [
-                    'F_PROGRAM_INDICATOR_PRIVATE_ADD',
-                    'F_PROGRAM_INDICATOR_PUBLIC_ADD',
-                    'F_PROGRAM_INDICATOR_DELETE',
-                ],
+                schemaName: 'programIndicator',
             },
             programIndicatorGroup: {
                 name: 'Program indicator group',
                 path: '/list/indicatorSection/programIndicatorGroup',
                 description: '', // @TODO
-                permissions: [
-                    'F_PROGAM_INDICATOR_GROUP_PRIVATE_ADD',
-                    'F_PROGAM_INDICATOR_GROUP_PUBLIC_ADD',
-                    'F_PROGAM_INDICATOR_GROUP_DELETE',
-                ],
+                schemaName: 'programIndicatorGroup',
             },
         },
     },
@@ -221,44 +153,28 @@ export const sections = {
                 path: '/list/organisationUnitSection/organisationUnit',
                 description:
                     'Create, modify, view and delete organisation units, which can be departments, offices, hospitals and clinics.',
-                permissions: [
-                    'F_ORGANISATION_UNIT_PRIVATE_ADD',
-                    'F_ORGANISATION_UNIT_PUBLIC_ADD',
-                    'F_ORGANISATION_UNIT_DELETE',
-                ],
+                schemaName: 'organisationUnit',
             },
             organisationUnitGroup: {
                 name: 'Organisation unit group',
                 path: '/list/organisationUnitSection/organisationUnitGroup',
                 description:
                     'Create, modify, view and delete organisation unit groups. Groups are used for improved analysis.',
-                permissions: [
-                    'F_ORGANISATION_UNIT_GROUP_PRIVATE_ADD',
-                    'F_ORGANISATION_UNIT_GROUP_PUBLIC_ADD',
-                    'F_ORGANISATION_UNIT_GROUP_DELETE',
-                ],
+                schemaName: 'organisationUnitGroup',
             },
             organisationUnitGroupSet: {
                 name: 'Organisation unit group set',
                 path: '/list/organisationUnitSection/organisationUnitGroupSet',
                 description:
                     'Create, modify, view and delete organisation unit group sets. Group sets are used for improved analysis.',
-                permissions: [
-                    'F_ORGANISATION_UNIT_GROUP_SET_PRIVATE_ADD',
-                    'F_ORGANISATION_UNIT_GROUP_SET_PUBLIC_ADD',
-                    'F_ORGANISATION_UNIT_GROUP_SET_DELETE',
-                ],
+                schemaName: 'organisationUnitGroupSet',
             },
             organisationUnitLevel: {
                 name: 'Organisation unit level',
                 path: '/list/organisationUnitSection/organisationUnitLevel',
                 description:
                     'Create, modify, view and delete descriptive names for the organisation unit levels in the system.',
-                permissions: [
-                    'F_ORGANISATION_UNIT_LEVEL_PRIVATE_ADD',
-                    'F_ORGANISATION_UNIT_LEVEL_PUBLIC_ADD',
-                    'F_ORGANISATION_UNIT_LEVEL_DELETE',
-                ],
+                schemaName: 'organisationUnitLevel',
             },
             hierarchyOption: {
                 name: 'Hierarchy options',
@@ -282,64 +198,40 @@ export const sections = {
                 path: '/list/programSection/program',
                 description:
                     '"Create modify and view programs. A program has program stages and defines which actions should be taken at each stage.',
-                permissions: [
-                    'F_PROGRAM_PRIVATE_ADD',
-                    'F_PROGRAM_PUBLICE_ADD',
-                    'F_PROGRAM_DELETE',
-                ],
+                schemaName: 'program',
             },
             trackedEntityAttribute: {
                 name: 'Tracked entity attribute',
-                path: '/list/programSection/tackedEntityAttribute',
+                path: '/list/programSection/trackedEntityAttribute',
                 description:
                     'Create, modify and view program attributes. A program can have any number of attributes.',
-                permissions: [
-                    'F_TRACKED_ENTITY_ATTRIBUTE_PRIVATE_ADD',
-                    'F_TRACKED_ENTITY_ATTRIBUTE_PUBLICE_ADD',
-                    'F_TRACKED_ENTITY_ATTRIBUTE_DELETE',
-                ],
+                schemaName: 'trackedEntityAttribute',
             },
             trackedEntityType: {
                 name: 'Tracked entity type',
-                path: '/list/programSection/tackedEntityType',
+                path: '/list/programSection/trackedEntityType',
                 description:
                     'Define types of entities which can be tracked through the system, which can be anything from persons to commodities.',
-                permissions: [
-                    'F_TRACKED_ENTITY_TYPE_PRIVATE_ADD',
-                    'F_TRACKED_ENTITY_TYPE_PUBLICE_ADD',
-                    'F_TRACKED_ENTITY_TYPE_DELETE',
-                ],
+                schemaName: 'trackedEntityType',
             },
             relationshipType: {
                 name: 'Relationship type',
                 path: '/list/programSection/relationshipType',
                 description:
                     'Create, modify and view relationship types. A relationship is typically wife and husband or mother and child.',
-                permissions: [
-                    'F_RELATIONSHIP_TYPE_PRIVATE_ADD',
-                    'F_RELATIONSHIP_TYPE_PUBLICE_ADD',
-                    'F_RELATIONSHIP_TYPE_DELETE',
-                ],
+                schemaName: 'relationshipType',
             },
             programRule: {
                 name: 'Program rule',
                 path: '/list/programSection/programRule',
                 description: '', // @TODO
-                permissions: [
-                    'F_PROGRAM_RULE_PRIVATE_ADD',
-                    'F_PROGRAM_RULE_PUBLICE_ADD',
-                    'F_PROGRAM_RULE_DELETE',
-                ],
+                schemaName: 'programRule',
             },
             programRuleVariable: {
                 name: 'Program rule variable',
                 path: '/list/programSection/programRuleVariable',
                 description: '', // @TODO
-                permissions: [
-                    'F_PROGRAM_RULE_VARIABLE_PRIVATE_ADD',
-                    'F_PROGRAM_RULE_VARIABLE_PUBLICE_ADD',
-                    'F_PROGRAM_RULE_VARIABLE_DELETE',
-                ],
+                schemaName: 'programRuleVariable',
             },
         },
     },
@@ -353,27 +245,20 @@ export const sections = {
                 path: '/list/validationSectin/validationRule',
                 description:
                     'Add, modify, view and delete validation rules. Anomalies can be discovered by running validation rules against the data.',
-                permissions: [
-                    'F_VALIDATION_RULE_PRIVATE_ADD',
-                    'F_VALIDATION_RULE_PUBLICE_ADD',
-                    'F_VALIDATION_RULE_DELETE',
-                ],
+                schemaName: 'validationRule',
             },
             validationRuleGroup: {
                 name: 'Validation rule group',
                 path: '/list/validationSectin/validationRuleGroup',
                 description:
                     'Add, modify, view and delete validation rule groups. Provides the ability to group and run validation rules together.',
-                permissions: [
-                    'F_VALIDATION_RULE_GROUP_PRIVATE_ADD',
-                    'F_VALIDATION_RULE_GROUP_PUBLICE_ADD',
-                    'F_VALIDATION_RULE_GROUP_DELETE',
-                ],
+                schemaName: 'validationRuleGroup',
             },
             validationNotification: {
                 name: 'Validation notification',
                 path: '/list/validationSectin/validationNotification',
                 description: '', // @TODO
+                schemaName: 'validationNotificationTemplate', // @TODO
                 permissions: [
                     'F_VALIDATION_NOTIFICATION_PRIVATE_ADD',
                     'F_VALIDATION_NOTIFICATION_PUBLICE_ADD',
@@ -392,147 +277,91 @@ export const sections = {
                 description:
                     'Create constants which can be included in expressions of indicator and validation rules.',
                 path: '/list/otherSection/constant',
-                permissions: [
-                    'F_CONSTANT_PRIVATE_ADD',
-                    'F_CONSTANT_PUBLICE_ADD',
-                    'F_CONSTANT_DELETE',
-                ],
+                schemaName: 'constant',
             },
             attribute: {
                 name: 'Attribute',
                 path: '/list/otherSection/attribute',
                 description: 'Create, modify and view attributes.',
-                permissions: [
-                    'F_ATTRIBUTE_PRIVATE_ADD',
-                    'F_ATTRIBUTE_PUBLICE_ADD',
-                    'F_ATTRIBUTE_DELETE',
-                ],
+                schemaName: 'attribute',
             },
             optionSet: {
                 name: 'Option set',
                 path: '/list/otherSection/optionSet',
                 description:
                     'Create option sets which can be included in data elements and produce drop-down lists in data entry forms.',
-                permissions: [
-                    'F_OPTION_SET_PRIVATE_ADD',
-                    'F_OPTION_SET_PUBLICE_ADD',
-                    'F_OPTION_SET_DELETE',
-                ],
+                schemaName: 'optionSet',
             },
             optionGroup: {
                 name: 'Option group',
                 path: '/list/otherSection/optionGroup',
                 description: '', // @TODO
-                permissions: [
-                    'F_OPTION_GROUP_PRIVATE_ADD',
-                    'F_OPTION_GROUP_PUBLICE_ADD',
-                    'F_OPTION_GROUP_DELETE',
-                ],
+                schemaName: 'optionGroup',
             },
             optionGroupSet: {
                 name: 'Option group set',
                 path: '/list/otherSection/optionGroupSet',
                 description: '', // @TODO
-                permissions: [
-                    'F_OPTION_GROUP_SET_PRIVATE_ADD',
-                    'F_OPTION_GROUP_SET_PUBLICE_ADD',
-                    'F_OPTION_GROUP_SET_DELETE',
-                ],
+                schemaName: 'optionGroupSet',
             },
             legend: {
                 name: 'Legend',
                 path: '/list/otherSection/legend',
                 description:
                     'Create, modify and view predefined legends for maps and other visualisations.',
-                permissions: [
-                    'F_LEGEND_PRIVATE_ADD',
-                    'F_LEGEND_PUBLICE_ADD',
-                    'F_LEGEND_DELETE',
-                ],
+                schemaName: 'legend',
             },
             predictor: {
                 name: 'Predictor',
                 path: '/list/otherSection/predictor',
                 description:
                     'Create predictors which can be used to predict future data values.',
-                permissions: [
-                    'F_PREDICTOR_PRIVATE_ADD',
-                    'F_PREDICTOR_PUBLICE_ADD',
-                    'F_PREDICTOR_DELETE',
-                ],
+                schemaName: 'predictor',
             },
             predictorGroup: {
                 name: 'Predictor group',
                 path: '/list/otherSection/predictorGroup',
                 description: '', // @TODO
-                permissions: [
-                    'F_PREDICTOR_GROUP_PRIVATE_ADD',
-                    'F_PREDICTOR_GROUP_PUBLICE_ADD',
-                    'F_PREDICTOR_GROUP_DELETE',
-                ],
+                schemaName: 'predictorGroup',
             },
             pushAnalysis: {
                 name: 'Push analysis',
                 path: '/list/otherSection/pushAnalysis',
                 description:
                     'Manage analytics to be emailed to specific user groups on a daily, weekly or monthly basis.',
-                permissions: [
-                    'F_PUSH_ANALYSIS_PRIVATE_ADD',
-                    'F_PUSH_ANALYSIS_PUBLICE_ADD',
-                    'F_PUSH_ANALYSIS_DELETE',
-                ],
+                schemaName: 'pushAnalysis',
             },
             externalMapLayer: {
                 name: 'External map layer',
                 path: '/list/otherSection/externalMapLayer',
                 description: 'Configure external map layers for use in GIS.',
-                permissions: [
-                    'F_EXTERNAL_MAP_LAYER_PRIVATE_ADD',
-                    'F_EXTERNAL_MAP_LAYER_PUBLICE_ADD',
-                    'F_EXTERNAL_MAP_LAYER_DELETE',
-                ],
+                schemaName: 'externalMapLayer',
             },
             dataApprovalLevel: {
                 name: 'Data approval level',
                 path: '/list/otherSection/dataApprovalLevel',
                 description: '', // @TODO
-                permissions: [
-                    'F_DATA_APPROVAL_LEVEL_PRIVATE_ADD',
-                    'F_DATA_APPROVAL_LEVEL_PUBLICE_ADD',
-                    'F_DATA_APPROVAL_LEVEL_DELETE',
-                ],
+                schemaName: 'dataApprovalLevel',
             },
             dataApprovalWorkflow: {
                 name: 'Data approval workflow',
                 path: '/list/otherSection/dataApprovalWorkflow',
                 description: '',
-                permissions: [
-                    'F_DATA_APPROVAL_WORKFLOW_PRIVATE_ADD',
-                    'F_DATA_APPROVAL_WORKFLOW_PUBLICE_ADD',
-                    'F_DATA_APPROVAL_WORKFLOW_DELETE',
-                ],
+                schemaName: 'dataApprovalWorkflow',
             },
             locale: {
                 name: 'Locale',
                 path: '/list/otherSection/locale',
                 description:
                     'Create and manage locales for database content. A locale is a combination of language and country.',
-                permissions: [
-                    'F_LOCALE_PRIVATE_ADD',
-                    'F_LOCALE_PUBLICE_ADD',
-                    'F_LOCALE_DELETE',
-                ],
+                schemaName: 'locale', // @TODO
             },
             sqlView: {
                 name: 'SQL View',
                 path: '/list/otherSection/sqlView',
                 description:
                     'Create SQL database views. These views will typically use the resource tables to provide convenient views for third-party tools.',
-                permissions: [
-                    'F_SQL_VIEW_PRIVATE_ADD',
-                    'F_SQL_VIEW_PUBLICE_ADD',
-                    'F_SQL_VIEW_DELETE',
-                ],
+                schemaName: 'sqlView',
             },
         },
     },

--- a/src/utils/authority/hasUserAuthorityForSection.js
+++ b/src/utils/authority/hasUserAuthorityForSection.js
@@ -1,7 +1,23 @@
-export const hasUserAuthorityForSection = (
+const extractAuthoritiesFromSchema = schema =>
+    schema.authorities.reduce(
+        (authorities, authority) => [...authorities, ...authority.authorities],
+        []
+    )
+
+export const hasUserAuthorityForSection = ({
     authorities,
     systemSettings,
-    permissions
-) =>
-    !systemSettings.keyRequireAddToView ||
-    permissions.some(permission => authorities.indexOf(permission) !== -1)
+    schema,
+    permissions,
+}) => {
+    const requiredPrivileges = schema
+        ? extractAuthoritiesFromSchema(schema)
+        : permissions
+
+    return (
+        !systemSettings.keyRequireAddToView ||
+        requiredPrivileges.some(
+            privilege => authorities.indexOf(privilege) !== -1
+        )
+    )
+}


### PR DESCRIPTION
Currently the `schemaName` in the `sections.js` matches the property key of the section, but I think there will be some irregularities. Until I've figured them out, and them decide on a proper way to refactor it, I'd propose we just leave it as is for now